### PR TITLE
Copy original message headers to new messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,11 @@
             <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/smooks/cartridges/camel/processor/SmooksProcessor.java
+++ b/src/main/java/org/smooks/cartridges/camel/processor/SmooksProcessor.java
@@ -128,6 +128,7 @@ public class SmooksProcessor implements Processor, Service, CamelContextAware {
             executionContext.setContentEncoding(charsetName);
         }
         exchange.getIn().setHeader(SMOOKS_EXECUTION_CONTEXT, executionContext);
+        executionContext.getBeanContext().addBean("MESSAGE_HEADERS", exchange.getMessage().getHeaders());
         setupSmooksReporting(executionContext);
 
         final Exports exports = smooks.getApplicationContext().getRegistry().lookup(new ExportsLookup());

--- a/src/test/java/org/smooks/cartridges/camel/processor/SmooksProcessor_BeanRouting_Test.java
+++ b/src/test/java/org/smooks/cartridges/camel/processor/SmooksProcessor_BeanRouting_Test.java
@@ -54,7 +54,9 @@ import org.smooks.cartridges.javabean.Bean;
 import org.smooks.io.payload.StringSource;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 
@@ -120,6 +122,31 @@ public class SmooksProcessor_BeanRouting_Test extends CamelTestSupport {
         assertThat((Coordinate) messageC.getBody(), is(new Coordinate(300, 400)));
         assertThat(messageB.getHeader(CORRELATION_ID), is(equalTo(messageC.getHeader(CORRELATION_ID))));
     }
+
+    @Test
+    public void processSmooksXmlConfiguredWithHeaders() throws Exception {
+        final String fromEndpoint = "direct:a3";
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(fromEndpoint).to("smooks://bean_routing_02.xml");
+            }
+        });
+        context.start();
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put("TEST_HEADER", "test");
+        sendBody(fromEndpoint, new StringSource("<coords><coord x='1' y='2' /><coord x='300' y='400' /></coords>"), headers);
+
+        final Message messageB = getExchange(getMockEndpoint("mock:b"));
+        Map originalHeaders = messageB.getHeader("MESSAGE_HEADERS", Map.class);
+        assertEquals("test", originalHeaders.get("TEST_HEADER"));
+
+        final Message messageC = getExchange(getMockEndpoint("mock:c"));
+        originalHeaders = messageC.getHeader("MESSAGE_HEADERS", Map.class);
+        assertEquals("test", originalHeaders.get("TEST_HEADER"));
+    }
+
 
     private Message getExchange(final MockEndpoint mockEndpoint) {
         return mockEndpoint.getExchanges().get(0).getIn();

--- a/src/test/resources/bean_routing_02.xml
+++ b/src/test/resources/bean_routing_02.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+  ========================LICENSE_START=================================
+  smooks-camel-cartridge
+  %%
+  Copyright (C) 2020 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
+                      xmlns:camel="https://www.smooks.org/xsd/smooks/camel-1.5.xsd"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="https://www.smooks.org/xsd/smooks-2.0.xsd https://www.smooks.org/xsd/smooks-2.0.xsd
+				                          https://www.smooks.org/xsd/smooks/javabean-1.6.xsd https://www.smooks.org/xsd/smooks/javabean-1.6.xsd
+				                          https://www.smooks.org/xsd/smooks/camel-1.5.xsd https://www.smooks.org/xsd/smooks/camel-1.5.xsd">
+    
+    <!-- Create a new Coordinate instance for every <coord> in the source message... -->
+    <jb:bean beanId="coordinate" class="org.smooks.cartridges.camel.Coordinate" createOnElement="coords/coord">
+        <jb:value property="x" data="coords/coord/@x" />
+        <jb:value property="y" data="coords/coord/@y" />
+    </jb:bean>
+    
+    <!-- Route "coordinate" bean instances for processing... -->
+    <camel:route beanId="coordinate" routeOnElement="coords/coord">
+        <camel:to endpoint="mock:b"><!-- coordinate.x < 200 --></camel:to>
+        <camel:to endpoint="mock:c" if="coordinate.x > 200"/>
+    </camel:route>
+
+</smooks-resource-list>


### PR DESCRIPTION
Modifies the SmooksProcessor class to add a bean to the BeanContext with the original message headers. If not correlation ID is set for the camel route, then the BeanRouter class sends the beans in the context as the headers, which now includes the original message headers.